### PR TITLE
Start upf containers separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ start: ./tmp
 	$(info *** Starting all containers...)
 	docker compose up -d
 
+start-upf: ./tmp
+	$(info *** Starting all containers...)
+	docker compose --profile upf up -d
+
 stop:
 	$(info *** Stopping all containers...)
 	docker compose down -t0 --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ ONOS_CURL := curl --fail -sSL --user onos:rocks --noproxy localhost
 .PHONY: $(SCENARIOS)
 
 start: ./tmp
-	$(info *** Starting all containers...)
+	$(info *** Starting ONOS and mininet...)
 	docker compose up -d
 
 start-upf: ./tmp
-	$(info *** Starting all containers...)
+	$(info *** Starting UPF containers...)
 	docker compose --profile upf up -d
 
 stop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,10 @@ services:
     privileged: true
     tty: true
     stdin_open: true
-    entrypoint: "/mininet/mn-entrypoint.sh"
+    entrypoint: "/mininet/entrypoint.sh"
     volumes:
       - ./tmp:/tmp
-      - ./topo:/topo
-      - ./bin:/up4/bin
-      - ./tmp/pcaps:/pcaps
+      - ./mininet:/mininet
     expose:
       - 50001 # leaf1
       - 50002 # leaf2
@@ -48,6 +46,8 @@ services:
 
   # P4-UPF services
   pfcp-agent:
+    profiles:
+      - upf
     image: ${PFCP_AGENT_IMAGE}
     platform: linux/amd64
     hostname: pfcp-agent
@@ -65,6 +65,8 @@ services:
     ports:
       - "8080:8080" # HTTP: REST API for slice meter configuration
   smf-sim:
+    profiles:
+      - upf
     image: ${PFCPSIM_IMAGE}
     platform: linux/amd64
     hostname: smf-sim

--- a/mininet/entrypoint.sh
+++ b/mininet/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # SPDX-FileCopyrightText: 2022-present Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
This solves the periodic warn log in ONOS caused by the lack of the necessary up4 netcfg.
With this change, when invoking `make start` only onos and mininet are started. pfcp-agent and smf-sim can be started by running `make start-upf`.

cc @charlesmcchan 